### PR TITLE
Enable ability to batch send events to New Relic

### DIFF
--- a/src/Events/BulkCustomEventEvent.php
+++ b/src/Events/BulkCustomEventEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace CarAdvice\NewRelic\CustomEvents\Events;
+
+
+use CarAdvice\NewRelic\CustomEvents\Models\CustomEvent;
+
+class BulkCustomEventEvent
+{
+    /**
+     * @var CustomEvent[]
+     */
+    public $customEvents = [];
+
+    /**
+     * CustomEventEvent constructor.
+     * @param CustomEvent[] $customEvents
+     */
+    public function __construct(array $customEvents)
+    {
+        foreach($customEvents as $customEvent) {
+
+            $this->customEvents[] = $customEvent->toArray();
+        }
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -5,7 +5,9 @@ namespace CarAdvice\NewRelic\CustomEvents;
 
 
 use CarAdvice\NewRelic\CustomEvents\Contracts\ApiClientContract;
+use CarAdvice\NewRelic\CustomEvents\Events\BulkCustomEventEvent;
 use CarAdvice\NewRelic\CustomEvents\Events\CustomEventEvent;
+use CarAdvice\NewRelic\CustomEvents\Listeners\SendBulkCustomEvent;
 use CarAdvice\NewRelic\CustomEvents\Listeners\SendCustomEvent;
 use CarAdvice\NewRelic\CustomEvents\Services\NewRelic\ApiClient;
 use GuzzleHttp\Client;
@@ -59,6 +61,7 @@ class LaravelServiceProvider extends ServiceProvider
         /** @var Dispatcher $eventDispatcher */
         $eventDispatcher = $this->app->make(Dispatcher::class);
         $eventDispatcher->listen(CustomEventEvent::class, SendCustomEvent::class);
+        $eventDispatcher->listen(BulkCustomEventEvent::class, SendBulkCustomEvent::class);
     }
 
     /**

--- a/src/Listeners/SendBulkCustomEvent.php
+++ b/src/Listeners/SendBulkCustomEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace CarAdvice\NewRelic\CustomEvents\Listeners;
+
+
+use CarAdvice\NewRelic\CustomEvents\Contracts\ApiClientContract;
+use CarAdvice\NewRelic\CustomEvents\Events\BulkCustomEventEvent;
+
+class SendBulkCustomEvent
+{
+    /**
+     * @var ApiClientContract
+     */
+    private $client;
+
+    public function __construct(ApiClientContract $client)
+    {
+        $this->client = $client;
+    }
+
+    public function handle(BulkCustomEventEvent $events)
+    {
+        $this->client->send($events->customEvents);
+    }
+}


### PR DESCRIPTION
Add the ability to send multiple events with a single API call to New Relic